### PR TITLE
faster unittest

### DIFF
--- a/client/van_connector_create_test.go
+++ b/client/van_connector_create_test.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"sort"
 	"strings"
@@ -17,11 +18,10 @@ import (
 )
 
 func TestConnectorCreateError(t *testing.T) {
+	cli, err := newMockClient("skupper", "", "")
+	assert.Check(t, err)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-
-	// Create the client
-	cli, err := newMockClient("skupper", "", "")
 
 	err = cli.VanConnectorCreate(ctx, "./somefile.yaml", types.VanConnectorCreateOptions{
 		Name: "",
@@ -39,18 +39,22 @@ func TestConnectorCreateInterior(t *testing.T) {
 		secretsExpected []string
 	}{
 		{
-			doc:             "Expect generated name to be conn1",
-			expectedError:   "",
+			doc:           "Expect generated name to be conn1",
+			expectedError: "",
+			//connName:        "connNamemustbedifferent",
 			connName:        "",
 			secretsExpected: []string{"conn1"},
 		},
 		{
-			doc:             "Expect secret name to be as provided: conn2",
+			doc:             "Expect secret name to be as provided: conn22",
 			expectedError:   "",
-			connName:        "conn2",
-			secretsExpected: []string{"conn2"},
+			connName:        "conn22",
+			secretsExpected: []string{"conn22"},
 		},
 	}
+
+	//TODO do a symple loop verifying and asserting no repeated table
+	//connection.
 
 	trans := cmp.Transformer("Sort", func(in []string) []string {
 		out := append([]string(nil), in...)
@@ -61,41 +65,44 @@ func TestConnectorCreateInterior(t *testing.T) {
 	testPath := "./tmp/"
 	os.Mkdir(testPath, 0755)
 
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	secretsFound := []string{}
+
+	cli, err := newMockClient("skupper", "", "")
+	assert.Check(t, err)
+
+	informers := informers.NewSharedInformerFactory(cli.KubeClient, 0)
+	secretsInformer := informers.Core().V1().Secrets().Informer()
+	secretsInformer.AddEventHandler(&cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj interface{}) {
+			secret := obj.(*corev1.Secret)
+			if !strings.HasPrefix(secret.Name, "skupper") {
+				secretsFound = append(secretsFound, secret.Name)
+			}
+		},
+	})
+
+	informers.Start(ctx.Done())
+	cache.WaitForCacheSync(ctx.Done(), secretsInformer.HasSynced)
+
+	err = cli.VanRouterCreate(ctx, types.VanRouterCreateOptions{
+		SkupperName:       "skupper",
+		IsEdge:            false,
+		EnableController:  true,
+		EnableServiceSync: true,
+		EnableConsole:     false,
+		AuthMode:          "",
+		User:              "",
+		Password:          "",
+		ClusterLocal:      true,
+	})
+	assert.Check(t, err, "Unable to create VAN router")
+
 	for _, c := range testcases {
-		ctx, cancel := context.WithCancel(context.Background())
-		defer cancel()
 
-		secretsFound := []string{}
-
-		cli, err := newMockClient("skupper", "", "")
-
-		informers := informers.NewSharedInformerFactory(cli.KubeClient, 0)
-		secretsInformer := informers.Core().V1().Secrets().Informer()
-		secretsInformer.AddEventHandler(&cache.ResourceEventHandlerFuncs{
-			AddFunc: func(obj interface{}) {
-				secret := obj.(*corev1.Secret)
-				if !strings.HasPrefix(secret.Name, "skupper") {
-					secretsFound = append(secretsFound, secret.Name)
-				}
-			},
-		})
-
-		informers.Start(ctx.Done())
-		cache.WaitForCacheSync(ctx.Done(), secretsInformer.HasSynced)
-
-		err = cli.VanRouterCreate(ctx, types.VanRouterCreateOptions{
-			SkupperName:       "skupper",
-			IsEdge:            false,
-			EnableController:  true,
-			EnableServiceSync: true,
-			EnableConsole:     false,
-			AuthMode:          "",
-			User:              "",
-			Password:          "",
-			ClusterLocal:      true,
-		})
-		assert.Check(t, err, "Unable to create VAN router")
-
+		//is it connecting to itself?
 		err = cli.VanConnectorTokenCreate(ctx, c.connName, testPath+c.connName+".yaml")
 		assert.Check(t, err, "Unable to create token")
 
@@ -107,9 +114,13 @@ func TestConnectorCreateInterior(t *testing.T) {
 
 		// TODO: make more deterministic
 		time.Sleep(time.Second * 1)
+		fmt.Printf("secretsFound= %q", secretsFound)
 		assert.Assert(t, cmp.Equal(c.secretsExpected, secretsFound, trans), c.doc)
+
+		secretsFound = []string{} //simple "Tear Down"
 	}
 
 	// clean up
+	//defer this?
 	os.RemoveAll(testPath)
 }


### PR DESCRIPTION
Test duration reduced notably:
--- PASS: TestConnectorCreateInterior (0.97s)                                                                                                                                                                                          
--- PASS: TestConnectorCreateInterior (4.60s)

Probably the same approach should be used in the remaining tests, I think almost all cases are similar.